### PR TITLE
(Android) Feat: Improved statusbar height fetching

### DIFF
--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -16,10 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  *
-*/
+ */
 package org.apache.cordova.statusbar;
 
-import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.Insets;
@@ -30,6 +29,10 @@ import android.view.WindowManager;
 import android.view.WindowMetrics;
 import android.view.WindowInsets;
 
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
+
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaArgs;
 import org.apache.cordova.CordovaInterface;
@@ -38,10 +41,24 @@ import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.LOG;
 import org.apache.cordova.PluginResult;
 import org.json.JSONException;
-import java.util.Arrays;
 
 public class StatusBar extends CordovaPlugin {
     private static final String TAG = "StatusBar";
+
+    private static final String ACTION_HIDE = "hide";
+    private static final String ACTION_SHOW = "show";
+    private static final String ACTION_READY = "_ready";
+    private static final String ACTION_HEIGHT = "height";
+    private static final String ACTION_BACKGROUND_COLOR_BY_HEX_STRING = "backgroundColorByHexString";
+    private static final String ACTION_OVERLAYS_WEB_VIEW = "overlaysWebView";
+    private static final String ACTION_STYLE_DEFAULT = "styleDefault";
+    private static final String ACTION_STYLE_LIGHT_CONTENT = "styleLightContent";
+
+    private static final String STYLE_DEFAULT = "default";
+    private static final String STYLE_LIGHT_CONTENT = "lightcontent";
+
+    private AppCompatActivity activity;
+    private Window window;
 
     /**
      * Sets the context of the Command. This can then be used to do things like
@@ -55,27 +72,24 @@ public class StatusBar extends CordovaPlugin {
         LOG.v(TAG, "StatusBar: initialization");
         super.initialize(cordova, webView);
 
-        this.cordova.getActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                // Clear flag FLAG_FORCE_NOT_FULLSCREEN which is set initially
-                // by the Cordova.
-                Window window = cordova.getActivity().getWindow();
-                window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+        activity = this.cordova.getActivity();
+        window = activity.getWindow();
 
-                // Read 'StatusBarOverlaysWebView' from config.xml, default is true.
-                setStatusBarTransparent(preferences.getBoolean("StatusBarOverlaysWebView", true));
+        activity.runOnUiThread(() -> {
+            // Clear flag FLAG_FORCE_NOT_FULLSCREEN which is set initially
+            // by the Cordova.
+            window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
 
-                // Read 'StatusBarBackgroundColor' from config.xml, default is #000000.
-                setStatusBarBackgroundColor(preferences.getString("StatusBarBackgroundColor", "#000000"));
+            // Read 'StatusBarOverlaysWebView' from config.xml, default is true.
+            setStatusBarTransparent(preferences.getBoolean("StatusBarOverlaysWebView", true));
 
-                // Read 'StatusBarStyle' from config.xml, default is 'lightcontent'.
-                String styleSetting = preferences.getString("StatusBarStyle", "lightcontent");
-                if (styleSetting.equalsIgnoreCase("blacktranslucent") || styleSetting.equalsIgnoreCase("blackopaque")) {
-                    LOG.w(TAG, styleSetting +" is deprecated and will be removed in next major release, use lightcontent");
-                }
-                setStatusBarStyle(styleSetting);
-            }
+            // Read 'StatusBarBackgroundColor' from config.xml, default is #000000.
+            setStatusBarBackgroundColor(preferences.getString("StatusBarBackgroundColor", "#000000"));
+
+            // Read 'StatusBarStyle' from config.xml, default is 'lightcontent'.
+            setStatusBarStyle(
+                preferences.getString("StatusBarStyle", STYLE_LIGHT_CONTENT).toLowerCase()
+            );
         });
     }
 
@@ -88,139 +102,79 @@ public class StatusBar extends CordovaPlugin {
      * @return                  True if the action was valid, false otherwise.
      */
     @Override
-    public boolean execute(final String action, final CordovaArgs args, final CallbackContext callbackContext) throws JSONException {
+    public boolean execute(final String action, final CordovaArgs args, final CallbackContext callbackContext) {
         LOG.v(TAG, "Executing action: " + action);
-        final Activity activity = this.cordova.getActivity();
-        final Window window = activity.getWindow();
 
-        if ("_ready".equals(action)) {
-            boolean statusBarVisible = (window.getAttributes().flags & WindowManager.LayoutParams.FLAG_FULLSCREEN) == 0;
-            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, statusBarVisible));
-            return true;
-        }
+        switch (action) {
+            case ACTION_READY:
+                boolean statusBarVisible = (window.getAttributes().flags & WindowManager.LayoutParams.FLAG_FULLSCREEN) == 0;
+                callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, statusBarVisible));
+                return true;
 
-        if ("height".equals(action)) {
-            float statusBarHeight = getStatusBarHeight();
-            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, statusBarHeight));
-            return true;
-        }
+            case ACTION_SHOW:
+                activity.runOnUiThread(() -> {
+                    int uiOptions = window.getDecorView().getSystemUiVisibility();
+                    uiOptions &= ~View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+                    uiOptions &= ~View.SYSTEM_UI_FLAG_FULLSCREEN;
 
-        if ("show".equals(action)) {
-            this.cordova.getActivity().runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    // SYSTEM_UI_FLAG_FULLSCREEN is available since JellyBean, but we
-                    // use KitKat here to be aligned with "Fullscreen"  preference
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                        int uiOptions = window.getDecorView().getSystemUiVisibility();
-                        uiOptions &= ~View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
-                        uiOptions &= ~View.SYSTEM_UI_FLAG_FULLSCREEN;
-
-                        window.getDecorView().setSystemUiVisibility(uiOptions);
-                    }
+                    window.getDecorView().setSystemUiVisibility(uiOptions);
 
                     // CB-11197 We still need to update LayoutParams to force status bar
                     // to be hidden when entering e.g. text fields
                     window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-                }
-            });
-            return true;
-        }
+                });
+                return true;
 
-        if ("hide".equals(action)) {
-            this.cordova.getActivity().runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    // SYSTEM_UI_FLAG_FULLSCREEN is available since JellyBean, but we
-                    // use KitKat here to be aligned with "Fullscreen"  preference
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                        int uiOptions = window.getDecorView().getSystemUiVisibility()
-                                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                                | View.SYSTEM_UI_FLAG_FULLSCREEN;
+            case ACTION_HIDE:
+                activity.runOnUiThread(() -> {
+                    int uiOptions = window.getDecorView().getSystemUiVisibility()
+                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_FULLSCREEN;
 
-                        window.getDecorView().setSystemUiVisibility(uiOptions);
-                    }
+                    window.getDecorView().setSystemUiVisibility(uiOptions);
 
                     // CB-11197 We still need to update LayoutParams to force status bar
                     // to be hidden when entering e.g. text fields
                     window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-                }
-            });
-            return true;
-        }
+                });
+                return true;
 
-        if ("backgroundColorByHexString".equals(action)) {
-            this.cordova.getActivity().runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
+            case ACTION_HEIGHT:
+                float statusBarHeight = getStatusBarHeight();
+                callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, statusBarHeight));
+                return true;
+
+            case ACTION_BACKGROUND_COLOR_BY_HEX_STRING:
+                activity.runOnUiThread(() -> {
                     try {
                         setStatusBarBackgroundColor(args.getString(0));
                     } catch (JSONException ignore) {
                         LOG.e(TAG, "Invalid hexString argument, use f.i. '#777777'");
                     }
-                }
-            });
-            return true;
-        }
+                });
+                return true;
 
-        if ("overlaysWebView".equals(action)) {
-            if (Build.VERSION.SDK_INT >= 21) {
-                this.cordova.getActivity().runOnUiThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            setStatusBarTransparent(args.getBoolean(0));
-                        } catch (JSONException ignore) {
-                            LOG.e(TAG, "Invalid boolean argument");
-                        }
+            case ACTION_OVERLAYS_WEB_VIEW:
+                activity.runOnUiThread(() -> {
+                    try {
+                        setStatusBarTransparent(args.getBoolean(0));
+                    } catch (JSONException ignore) {
+                        LOG.e(TAG, "Invalid boolean argument");
                     }
                 });
                 return true;
-            }
-            else return args.getBoolean(0) == false;
-        }
 
-        if ("styleDefault".equals(action)) {
-            this.cordova.getActivity().runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    setStatusBarStyle("default");
-                }
-            });
-            return true;
-        }
+            case ACTION_STYLE_DEFAULT:
+                activity.runOnUiThread(() -> setStatusBarStyle(STYLE_DEFAULT));
+                return true;
 
-        if ("styleLightContent".equals(action)) {
-            this.cordova.getActivity().runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    setStatusBarStyle("lightcontent");
-                }
-            });
-            return true;
-        }
+            case ACTION_STYLE_LIGHT_CONTENT:
+                activity.runOnUiThread(() -> setStatusBarStyle(STYLE_LIGHT_CONTENT));
+                return true;
 
-        if ("styleBlackTranslucent".equals(action)) {
-            this.cordova.getActivity().runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    setStatusBarStyle("blacktranslucent");
-                }
-            });
-            return true;
+            default:
+                return false;
         }
-
-        if ("styleBlackOpaque".equals(action)) {
-            this.cordova.getActivity().runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    setStatusBarStyle("blackopaque");
-                }
-            });
-            return true;
-        }
-
-        return false;
     }
 
     private float getStatusBarHeight() {
@@ -244,69 +198,45 @@ public class StatusBar extends CordovaPlugin {
     }
 
     private void setStatusBarBackgroundColor(final String colorPref) {
-        if (Build.VERSION.SDK_INT >= 21) {
-            if (colorPref != null && !colorPref.isEmpty()) {
-                final Window window = cordova.getActivity().getWindow();
-                // Method and constants not available on all SDKs but we want to be able to compile this code with any SDK
-                window.clearFlags(0x04000000); // SDK 19: WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-                window.addFlags(0x80000000); // SDK 21: WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-                try {
-                    // Using reflection makes sure any 5.0+ device will work without having to compile with SDK level 21
-                    window.getClass().getMethod("setStatusBarColor", int.class).invoke(window, Color.parseColor(colorPref));
-                } catch (IllegalArgumentException ignore) {
-                    LOG.e(TAG, "Invalid hexString argument, use f.i. '#999999'");
-                } catch (Exception ignore) {
-                    // this should not happen, only in case Android removes this method in a version > 21
-                    LOG.w(TAG, "Method window.setStatusBarColor not found for SDK level " + Build.VERSION.SDK_INT);
-                }
-            }
+        if (colorPref.isEmpty()) return;
+
+        int color;
+        try {
+            color = Color.parseColor(colorPref);
+        } catch (IllegalArgumentException ignore) {
+            LOG.e(TAG, "Invalid hexString argument, use f.i. '#999999'");
+            return;
         }
+
+        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS); // SDK 19-30
+        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS); // SDK 21
+        window.setStatusBarColor(color);
     }
 
-    private void setStatusBarTransparent(final boolean transparent) {
-        if (Build.VERSION.SDK_INT >= 21) {
-            final Window window = cordova.getActivity().getWindow();
-            if (transparent) {
-                window.getDecorView().setSystemUiVisibility(
-                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
-                window.setStatusBarColor(Color.TRANSPARENT);
-            }
-            else {
-                window.getDecorView().setSystemUiVisibility(
-                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                                | View.SYSTEM_UI_FLAG_VISIBLE);
-            }
+    private void setStatusBarTransparent(final boolean isTransparent) {
+        final Window window = cordova.getActivity().getWindow();
+        int visibility = isTransparent
+            ? View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+            : View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_VISIBLE;
+
+        window.getDecorView().setSystemUiVisibility(visibility);
+
+        if (isTransparent) {
+            window.setStatusBarColor(Color.TRANSPARENT);
         }
     }
 
     private void setStatusBarStyle(final String style) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (style != null && !style.isEmpty()) {
-                View decorView = cordova.getActivity().getWindow().getDecorView();
-                int uiOptions = decorView.getSystemUiVisibility();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !style.isEmpty()) {
+            View decorView = window.getDecorView();
+            WindowInsetsControllerCompat windowInsetsControllerCompat = WindowCompat.getInsetsController(window, decorView);
 
-                String[] darkContentStyles = {
-                    "default",
-                };
-
-                String[] lightContentStyles = {
-                    "lightcontent",
-                    "blacktranslucent",
-                    "blackopaque",
-                };
-
-                if (Arrays.asList(darkContentStyles).contains(style.toLowerCase())) {
-                    decorView.setSystemUiVisibility(uiOptions | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
-                    return;
-                }
-
-                if (Arrays.asList(lightContentStyles).contains(style.toLowerCase())) {
-                    decorView.setSystemUiVisibility(uiOptions & ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
-                    return;
-                }
-
-                LOG.e(TAG, "Invalid style, must be either 'default', 'lightcontent' or the deprecated 'blacktranslucent' and 'blackopaque'");
+            if (style.equals(STYLE_DEFAULT)) {
+                windowInsetsControllerCompat.setAppearanceLightStatusBars(true);
+            } else if (style.equals(STYLE_LIGHT_CONTENT)) {
+                windowInsetsControllerCompat.setAppearanceLightStatusBars(false);
+            } else {
+                LOG.e(TAG, "Invalid style, must be either 'default' or 'lightcontent'");
             }
         }
     }

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -20,11 +20,15 @@
 package org.apache.cordova.statusbar;
 
 import android.app.Activity;
+import android.content.Context;
 import android.graphics.Color;
+import android.graphics.Insets;
 import android.os.Build;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
+import android.view.WindowMetrics;
+import android.view.WindowInsets;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaArgs;
@@ -221,10 +225,20 @@ public class StatusBar extends CordovaPlugin {
 
     private float getStatusBarHeight() {
         float statusBarHeight = 0;
+        float scaleRatio = cordova.getActivity().getResources().getDisplayMetrics().density;
         int resourceId = cordova.getActivity().getResources().getIdentifier("status_bar_height", "dimen", "android");
         if (resourceId > 0) {
-            float scaleRatio = cordova.getActivity().getResources().getDisplayMetrics().density;
             statusBarHeight = cordova.getActivity().getResources().getDimension(resourceId) / scaleRatio;
+        }
+        float cutoutHeight = 0;
+        if(Build.VERSION.SDK_INT >= 30) {
+            WindowManager windowManager = (WindowManager) cordova.getActivity().getApplicationContext().getSystemService(Context.WINDOW_SERVICE);
+            WindowMetrics windowMetrics = windowManager.getCurrentWindowMetrics();
+            Insets insets = windowMetrics.getWindowInsets().getInsetsIgnoringVisibility(WindowInsets.Type.displayCutout()); // WindowInsets.Type.statusBars()
+            cutoutHeight = insets.top > 0 ? insets.top / scaleRatio : 0;
+        }
+        if(cutoutHeight > statusBarHeight) {
+            statusBarHeight = cutoutHeight;
         }
         return statusBarHeight;
     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

At least in the preview version of Android 13, the correct height of the statusbar was not obtained if the device had an active cutout (Android Emulator).

### Description
<!-- Describe your changes in detail -->

Now if a cutout larger than the status bar is detected at the top, this value will be returned.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Tested in Andoird 13 developer preview (Android Emulator) and Android 11 (Android Emulator)

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
